### PR TITLE
update dependency notation for correct limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-django = "^3.0"
+python = ">=3.9"
+django = ">=3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.0.0"


### PR DESCRIPTION
As pointed out in [this](https://github.com/astral-sh/uv/issues/11977) uv issue, the `^` notation sets an upper bound at < next major version, so as used, the depencies are declared as `django>=3.0,<4.0`.

This commit updates the dependency declaration to match the intent of the library, as expressed in it's classifiers and readme.